### PR TITLE
chore: Set deploymentName parameter for central-publishing-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,8 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
+              <deploymentName>jolokia-mcp-${project.version}</deploymentName>
+              <waitUntil>uploaded</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
I didn't switch to `central-publishing-maven-plugin` in main Jolokia project yet, but when I was releasing Pax Web I noticed that it's better to set this option. Otherwise you end up with:
<img width="313" height="540" alt="image" src="https://github.com/user-attachments/assets/7bf0826c-48ff-499e-b2c1-adbc0db30d35" />
